### PR TITLE
V2 audit/wp l3

### DIFF
--- a/contracts/v2/OrangeKyberswapProxy.sol
+++ b/contracts/v2/OrangeKyberswapProxy.sol
@@ -87,11 +87,6 @@ contract OrangeKyberswapProxy is OrangeSwapProxy {
             request.expectTokenIn.forceApprove(request.provider, type(uint256).max);
         }
 
-        // we also need to approve expectTokenOut because in some cases, part of the output may be taken as fee
-        if (request.expectTokenOut.allowance(address(this), request.provider) == 0) {
-            request.expectTokenOut.forceApprove(request.provider, type(uint256).max);
-        }
-
         // execute swap
         // output is directly sent to msg.sender
         request.provider.functionCall(request.swapCalldata, "OrangeKyberSwapProxy: low-level call failed");

--- a/test/OrangeDopexV2LPAutomator/v2/OrangeStrykeLPAutomatorV2Handler.t.sol
+++ b/test/OrangeDopexV2LPAutomator/v2/OrangeStrykeLPAutomatorV2Handler.t.sol
@@ -175,8 +175,10 @@ contract OrangeStrykeLPAutomatorV2Handler is Test {
         IOrangeSwapProxy.SwapInputRequest memory swapRequest,
         bytes memory flashLoanData
     ) external {
-        vm.prank(automatorOwner);
-        automator.setProxyWhitelist(swapProxy, true);
+        if (automator.asset().allowance(address(automator), swapProxy) == 0) {
+            vm.prank(automatorOwner);
+            automator.setProxyWhitelist(swapProxy, true);
+        }
 
         IOrangeStrykeLPAutomatorV2.RebalanceTick[] memory mintTicks = parseTicks(ticksMint);
         IOrangeStrykeLPAutomatorV2.RebalanceTick[] memory burnTicks = parseTicks(ticksBurn);

--- a/test/OrangeDopexV2LPAutomator/v2/RebalanceSlow.t.sol
+++ b/test/OrangeDopexV2LPAutomator/v2/RebalanceSlow.t.sol
@@ -25,7 +25,6 @@ contract TestOrangeStrykeLPAutomatorV2RebalanceSlow is WETH_USDC_Fixture {
     }
 
     function test_rebalance_flashLoanAndSwap_dynamic_Skip() public {
-        super.setUp();
         aHandler.deposit(100 ether, alice);
 
         (address router, bytes memory swapCalldata) = _buildKyberswapData(address(automator), 50);


### PR DESCRIPTION
- In OrangeKyberswapProxy, removed unnecessary approval of tokenOut for provider