### PR TITLE
[Squash merge] V2 audit/wp h1 

### DIFF
--- a/test-hardhat/mock/MockAutomatorV3.sol
+++ b/test-hardhat/mock/MockAutomatorV3.sol
@@ -71,6 +71,7 @@ contract MockAutomatorV3 is UUPSUpgradeable {
                                                     Balancer
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////*/
     address public balancer;
+    bytes32 private _flashLoanHash;
 
     uint256 public swapInputDelta;
 

--- a/test/OrangeDopexV2LPAutomator/v2/Rebalance.t.sol
+++ b/test/OrangeDopexV2LPAutomator/v2/Rebalance.t.sol
@@ -177,6 +177,33 @@ contract TestOrangeStrykeLPAutomatorV2Rebalance is WETH_USDC_Fixture {
         );
     }
 
+    function test_receiveFlashLoan_revertUnauthorized() public {
+        IERC20[] memory tokens = new IERC20[](1);
+        uint256[] memory amounts = new uint256[](1);
+        uint256[] memory feeAmounts = new uint256[](1);
+        bytes[] memory mintCalldata = new bytes[](1);
+        bytes[] memory burnCalldata = new bytes[](1);
+        bytes memory userData = abi.encode(
+            IOrangeStrykeLPAutomatorV2.FlashLoanUserData({
+                swapProxy: address(0),
+                swapRequest: IOrangeSwapProxy.SwapInputRequest({
+                    provider: address(0),
+                    swapCalldata: "",
+                    expectTokenIn: USDC,
+                    expectTokenOut: WETH,
+                    expectAmountIn: 1_000_000e6,
+                    inputDelta: 0
+                }),
+                mintCalldata: mintCalldata,
+                burnCalldata: burnCalldata
+            })
+        );
+
+        vm.expectRevert(IOrangeStrykeLPAutomatorV2.FlashLoan_Unauthorized.selector);
+        vm.prank(address(balancer));
+        automator.receiveFlashLoan(tokens, amounts, feeAmounts, userData);
+    }
+
     function _tickInit(
         int24 tickLower,
         uint256 amount0,


### PR DESCRIPTION
- Using _flashLoanHash to limit receiveFlashLoan() call from malicious sender